### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Para utilizar o AI CLI, você pode executar o comando `chat` seguido de um texto
    ./chat --setup
    ```
 
-   **Recomendo usar a extenção -force para forçar a instação das dependências**
+   **Recomendo usar a extensão -force para forçar a instalação das dependências**
    ```bash
    # Adiciona --break-system-packages ao instalar as dependências em Python
    ./chat --setup-force
@@ -74,7 +74,7 @@ Para utilizar o AI CLI, você pode executar o comando `chat` seguido de um texto
    ```bash
    ./chat --install-deps
    ```
-   **Recomendo usar a extenção -force para forçar a instação das dependências**
+   **Recomendo usar a extensão -force para forçar a instalação das dependências**
    ```bash
    # Adiciona --break-system-packages
    ./chat --install-deps-force


### PR DESCRIPTION
## Summary
- fix spelling of `extensão` and `instalação` in setup instructions

## Testing
- `./chat --check-deps`

------
https://chatgpt.com/codex/tasks/task_e_68779e992f848324a4abb0727cb0cffd