### PR TITLE
Add OpenAI Assistants provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ USO:
     chat "texto" [opções]
 
 OPÇÕES PRINCIPAIS:
-    --provider [openai|claude|deepseek|qwen|grok]  Escolhe o provider (padrão: openai)
+    --provider [openai|openai_assistant|claude|deepseek|qwen|grok]  Escolhe o provider (padrão: openai)
     --help, -h                  Mostra esta ajuda
     --version                   Mostra a versão
     --list-models               Lista modelos disponíveis
@@ -149,6 +149,7 @@ OPÇÕES DE CONFIGURAÇÃO / INSTALAÇÃO:
 
 OPÇÕES DE PROVIDER:
     --openai                    Usa OpenAI (padrão)
+    --assistant                 Usa Assistants API da OpenAI
     --anthropic                 Usa Anthropic
     --deepseek                  Usa DeepSeek
     --qwen                      Usa Qwen
@@ -182,6 +183,7 @@ OPÇÕES DE ENTRADA:
     --codigo ARQUIVO            Analisa arquivo de código
     --pdf ARQUIVO               Analisa arquivo PDF
     --texto ARQUIVO             Lê texto de arquivo
+    --files ARQ1 ARQ2...        Envia múltiplos arquivos para Assistants API
 
 EXEMPLOS:
     chat "Explique firewall"

--- a/chat
+++ b/chat
@@ -36,7 +36,7 @@ USO:
     chat "texto" [opções]
 
 OPÇÕES PRINCIPAIS:
-    --provider [openai|claude|deepseek|qwen|grok]  Escolhe o provider (padrão: openai)
+    --provider [openai|openai_assistant|claude|deepseek|qwen|grok]  Escolhe o provider (padrão: openai)
     --help, -h                  Mostra esta ajuda
     --version                   Mostra a versão
     --list-models               Lista modelos disponíveis
@@ -51,6 +51,7 @@ OPÇÕES DE CONFIGURAÇÃO / INSTALAÇÃO:
 
 OPÇÕES DE PROVIDER:
     --openai                    Usa OpenAI (padrão)
+    --assistant                 Usa Assistants API da OpenAI
     --anthropic                 Usa Anthropic
     --deepseek                  Usa DeepSeek
     --qwen                      Usa Qwen
@@ -84,6 +85,7 @@ OPÇÕES DE ENTRADA:
     --codigo ARQUIVO            Analisa arquivo de código
     --pdf ARQUIVO               Analisa arquivo PDF
     --texto ARQUIVO             Lê texto de arquivo
+    --files ARQ1 ARQ2...        Envia múltiplos arquivos para Assistants API
 
 EXEMPLOS:
     chat "Explique firewall"

--- a/config/models.json
+++ b/config/models.json
@@ -68,6 +68,42 @@
       }
     }
   },
+  "openai_assistant": {
+    "models": {
+      "fast": {
+        "model": "gpt-4o-mini",
+        "max_tokens": 4096,
+        "description": "rápido e econômico"
+      },
+      "cheap": {
+        "model": "gpt-4o-mini",
+        "max_tokens": 4096,
+        "description": "rápido e econômico"
+      },
+      "smart": {
+        "model": "gpt-4o",
+        "max_tokens": 16384,
+        "description": "equilibrado"
+      },
+      "smartest": {
+        "model": "o3-mini",
+        "max_tokens": 100000,
+        "description": "raciocínio profundo",
+        "is_o_model": true
+      },
+      "absurdo": {
+        "model": "o3",
+        "max_tokens": 100000,
+        "description": "máximo poder",
+        "is_o_model": true
+      },
+      "default": {
+        "model": "chatgpt-4o-latest",
+        "max_tokens": 8192,
+        "description": "padrão"
+      }
+    }
+  },
   "deepseek": {
     "models": {
       "fast": {

--- a/src/main.py
+++ b/src/main.py
@@ -39,6 +39,9 @@ class AIController:
         elif provider_name == 'openai':
             provider = self.provider_factory.create_provider('openai')
             return provider.call_api(mensagem, modelo, max_tokens, is_o_model=is_o_model, persona=args.persona)
+        elif provider_name == 'openai_assistant':
+            provider = self.provider_factory.create_provider('openai_assistant')
+            return provider.call_api(mensagem, modelo, max_tokens, persona=args.persona, files=args.files)
         else:
             # Handle other providers
             provider = self.provider_factory.create_provider(provider_name)

--- a/src/providers/factory.py
+++ b/src/providers/factory.py
@@ -1,4 +1,5 @@
 from providers.openai_provider import OpenAIProvider
+from providers.openai_assistant_provider import OpenAIAssistantProvider
 from providers.claude_provider import ClaudeProvider
 from providers.deepseek_provider import DeepSeekProvider
 from providers.alibaba_provider import Qwen3Provider
@@ -14,6 +15,7 @@ class ProviderFactory:
     
     _providers = {
         'openai': OpenAIProvider,
+        'openai_assistant': OpenAIAssistantProvider,
         'claude': ClaudeProvider,
         'deepseek': DeepSeekProvider,
         'qwen': Qwen3Provider,

--- a/src/providers/openai_assistant_provider.py
+++ b/src/providers/openai_assistant_provider.py
@@ -1,0 +1,101 @@
+import os
+import sys
+import time
+from typing import List
+
+from .base import BaseProvider
+from constants import DEFAULT_SYSTEM_PROMPT
+from utils.error_handler import SecureErrorHandler
+
+class OpenAIAssistantProvider(BaseProvider):
+    """Provider para OpenAI Assistants API"""
+
+    def __init__(self):
+        super().__init__(api_key=os.getenv('OPENAI_API_KEY'))
+        self.client = None
+        self.model = None
+        self.max_tokens = None
+
+    def _initialize_client(self):
+        """Inicializa o cliente OpenAI"""
+        if not self.api_key:
+            SecureErrorHandler.handle_error(
+                "api_key_missing",
+                Exception("OPENAI_API_KEY not found"),
+                context={"provider": "openai_assistant"},
+            )
+
+        try:
+            from openai import OpenAI
+            self.client = OpenAI(api_key=self.api_key)
+        except ImportError:
+            print("Erro: Biblioteca 'openai' não instalada. Execute: pip install openai", file=sys.stderr)
+            sys.exit(1)
+
+    def call_api(self, message: str, model: str, max_tokens: int, **kwargs):
+        """Chama a Assistants API"""
+        if not self.client:
+            self._initialize_client()
+
+        self.model = model
+        self.max_tokens = max_tokens
+
+        try:
+            persona = kwargs.get("persona", DEFAULT_SYSTEM_PROMPT)
+            files: List[str] = kwargs.get("files") or []
+            print(f"Usando Assistants API OpenAI: {model} (max_tokens: {max_tokens})", file=sys.stderr)
+
+            assistant = self.client.beta.assistants.create(
+                model=model,
+                instructions=persona,
+                tools=[{"type": "code_interpreter"}, {"type": "retrieval"}],
+            )
+
+            thread = self.client.beta.threads.create()
+
+            file_ids = []
+            for file_path in files:
+                try:
+                    with open(file_path, "rb") as f:
+                        uploaded = self.client.files.create(file=f, purpose="assistants")
+                        file_ids.append(uploaded.id)
+                except Exception as e:
+                    print(f"Erro ao enviar arquivo {file_path}: {e}", file=sys.stderr)
+
+            self.client.beta.threads.messages.create(
+                thread_id=thread.id,
+                role="user",
+                content=message,
+                file_ids=file_ids if file_ids else None,
+            )
+
+            run = self.client.beta.threads.runs.create(
+                thread_id=thread.id,
+                assistant_id=assistant.id,
+            )
+
+            while True:
+                run = self.client.beta.threads.runs.retrieve(thread_id=thread.id, run_id=run.id)
+                if run.status == "completed":
+                    break
+                if run.status in {"failed", "expired", "cancelled"}:
+                    raise Exception(f"Run finalizado com status {run.status}")
+                time.sleep(1)
+
+            messages = self.client.beta.threads.messages.list(thread_id=thread.id, order="desc")
+            for msg in messages.data:
+                if msg.role == "assistant" and msg.content:
+                    conteudo = msg.content[0].text.value
+                    if conteudo:
+                        return conteudo
+            return ""
+        except Exception as e:
+            SecureErrorHandler.handle_error(
+                "api_error",
+                e,
+                context={"provider": "openai_assistant", "model": model},
+            )
+
+    def get_available_models(self):
+        """Retorna modelos disponíveis"""
+        return ["gpt-4o-mini", "gpt-4o", "chatgpt-4o-latest", "o3-mini", "o3"]

--- a/src/utils/argumentos.py
+++ b/src/utils/argumentos.py
@@ -25,11 +25,12 @@ class CLIArgumentParser:
         parser.add_argument('--secure', action='store_true', help='Usa chaves de API para autenticação')
 
         # Providers
-        parser.add_argument('--provider', 
-                          choices=['aws', 'openai', 'claude', 'deepseek', 'qwen', 'dryrun', 'grok', 'whisper','groq'], 
+        parser.add_argument('--provider',
+                          choices=['aws', 'openai', 'openai_assistant', 'claude', 'deepseek', 'qwen', 'dryrun', 'grok', 'whisper','groq'],
                           default='groq',
                           help='Escolha o provider da API de chat')
         parser.add_argument('--openai', action='store_true', help='Usa API da OpenAI')
+        parser.add_argument('--assistant', action='store_true', help='Usa Assistants API da OpenAI')
         parser.add_argument('--claude', action='store_true', help='Usa API da Anthropic')
         parser.add_argument('--deepseek', action='store_true', help='Usa API da DeepSeek')
         parser.add_argument('--qwen', action='store_true', help='Usa API da Alibaba')
@@ -62,6 +63,7 @@ class CLIArgumentParser:
         parser.add_argument('--codigo', type=str)
         parser.add_argument('--pdf', type=str)
         parser.add_argument('--texto', type=str)
+        parser.add_argument('--files', nargs='+', help='Arquivos para Assistants API')
         
         # Personalidade ou código
         parser.add_argument('--persona', type=str, help='Personalidade a ser usada')
@@ -125,6 +127,8 @@ class CLIArgumentParser:
             args.provider = 'groq'
         elif args.openai:
             args.provider = 'openai'
+        elif args.assistant:
+            args.provider = 'openai_assistant'
 
     
     def _process_persona(self, args):


### PR DESCRIPTION
## Summary
- introduce `openai_assistant` provider implementing Assistants API
- allow multiple file inputs with `--files`
- expose new provider in CLI and help docs
- document new provider and arguments in README
- extend model configuration for `openai_assistant`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688829c9b7e08324bb7666dedd3d4519