### PR TITLE
feat: add persistent conversation option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 Thumbs.db
 **/__pycache__
 tests/
+.openai_response_id
 voice-chat/node_modules/

--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ OPÇÕES DE PROVIDER:
     --groq                      Usa Groq
     --gemini                    Usa Gemini
 
+OPÇÕES DE HISTÓRICO:
+    --persistent [yes|no]       Armazena ou remove histórico no servidor da OpenAI (usar com --openai)
+
 OPÇÕES DE PERSONALIDADE:
     --persona NOME              Define a personalidade da IA (ex: --persona "engenheiro de software")
     --code LINGUAGEM            Gera código sem explicações

--- a/src/main.py
+++ b/src/main.py
@@ -40,7 +40,14 @@ class AIController:
             return mensagem
         elif provider_name == 'openai':
             provider = self.provider_factory.create_provider('openai')
-            return provider.call_api(mensagem, modelo, max_tokens, is_o_model=is_o_model, persona=args.persona)
+            return provider.call_api(
+                mensagem,
+                modelo,
+                max_tokens,
+                is_o_model=is_o_model,
+                persona=args.persona,
+                persistent=getattr(args, 'persistent', None)
+            )
         elif provider_name == 'assistant':
             provider = self.provider_factory.create_provider('assistant')
             return provider.call_api(mensagem, modelo, max_tokens, persona=args.persona,is_o_model=is_o_model, files=args.arquivos)

--- a/src/utils/argumentos.py
+++ b/src/utils/argumentos.py
@@ -73,6 +73,8 @@ class CLIArgumentParser:
         # Outros
         parser.add_argument('--max-tokens', type=int)
         parser.add_argument('--list-models', action='store_true')
+        parser.add_argument('--persistent', choices=['yes', 'no'],
+                            help='Mantém histórico de conversas na OpenAI')
         
         return parser
     
@@ -110,6 +112,11 @@ class CLIArgumentParser:
         # Validação para modelo absurdo
         if args.absurdo and args.provider not in ['openai', 'groq']:
             print("Erro: --absurdo disponível apenas para OpenAI e Groq", file=sys.stderr)
+            sys.exit(1)
+
+        # Validação para modo persistente
+        if args.persistent and not (args.openai or args.provider == 'openai'):
+            print("Erro: --persistent só pode ser usado com --openai", file=sys.stderr)
             sys.exit(1)
     
     def _process_provider_shortcuts(self, args):


### PR DESCRIPTION
## Summary
- add `--persistent` CLI flag to store or clear OpenAI conversation history
- implement history management in OpenAI provider
- document persistent usage and ignore history file

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e0db8bba88324b38271ab2a17c4a8